### PR TITLE
Making Releases only Manually Triggerable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,16 @@ on:
         required: true
         type: string
         default: 'v*.*.*'
-  push:
-    branches:
-      - master
-    tags:
-      - 'v*.*.*'
+      draft:
+        description: 'Is this a draft release?'
+        required: false
+        type: boolean
+        default: false
+      prerelease:
+        description: 'Is this a pre-release version?'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   # Build and Test to make sure we put out a good release
@@ -38,9 +43,7 @@ jobs:
           rm bin.tar
 
 ## Doing the complicated part of the release management
-########## If we a dispatch, then we checkout and create a new tag for the release
       - name: Create Tag
-        if: github.event_name == 'workflow_dispatch'
         uses: actions/github-script@v7
         with:
           script: |
@@ -51,16 +54,15 @@ jobs:
               sha: context.sha
             })
 
-########## Otherwise we are just building the release
       - name: Create Release
-        if: github.event_name == 'push'
         uses: softprops/action-gh-release@v2
         with:
           body: "Release of MAESTRO executables built for x64 Linux"
           files: bin/*
           fail_on_unmatched_files: true
-          prerelease: false
-          draft: false
+          prerelease: ${{ inputs.prerelease }}
+          draft: ${{ inputs.draft }}
+          tag: refs/tags/${{ inputs.tag_string }}
           generate_release_notes: true
           name: ${{ github.ref_name }} Release
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,6 @@ jobs:
           draft: ${{ inputs.draft }}
           tag_name: refs/tags/${{ inputs.tag_string }}
           generate_release_notes: true
-          name: ${{ github.ref_name }} Release
+          name: ${{ inpus.tag_string }} Release
 
   

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,6 @@ jobs:
           draft: ${{ inputs.draft }}
           tag_name: refs/tags/${{ inputs.tag_string }}
           generate_release_notes: true
-          name: ${{ inpus.tag_string }} Release
+          name: ${{ inputs.tag_string }} Release
 
   

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,16 +39,17 @@ jobs:
 
 ## Doing the complicated part of the release management
 ########## If we a dispatch, then we checkout and create a new tag for the release
-      - name: Checkout code
+      - name: Create Tag
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
-
-      - name: Create a new tag
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          cd ${{ github.workspace }}
-          git tag -a ${{ inputs.tag_string }} -m "Release ${{ inputs.tag_string }}"
-          git push --tags
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${{ inputs.tag_string }}`,
+              sha: context.sha
+            })
 
 ########## Otherwise we are just building the release
       - name: Create Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,16 @@
 name: Make Release
 
 on:
-  workflow_call:
+  workflow_dispatch:
+    inputs:
+      tag_string:
+        description: 'Release version'
+        required: true
+        type: string
+        default: 'v*.*.*'
   push:
+    branches:
+      - master
     tags:
       - 'v*.*.*'
 
@@ -29,14 +37,29 @@ jobs:
           tar -xvf bin.tar
           rm bin.tar
 
+## Doing the complicated part of the release management
+########## If we a dispatch, then we checkout and create a new tag for the release
+      - name: Checkout code
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+
+      - name: Create a new tag
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          cd ${{ github.workspace }}
+          git tag -a ${{ inputs.tag_string }} -m "Release ${{ inputs.tag_string }}"
+          git push --tags
+
+########## Otherwise we are just building the release
       - name: Create Release
+        if: github.event_name == 'push'
         uses: softprops/action-gh-release@v2
         with:
           body: "Release of MAESTRO executables built for x64 Linux"
           files: bin/*
           fail_on_unmatched_files: true
           prerelease: false
-          draft: true
+          draft: false
           generate_release_notes: true
           name: ${{ github.ref_name }} Release
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
           fail_on_unmatched_files: true
           prerelease: ${{ inputs.prerelease }}
           draft: ${{ inputs.draft }}
-          tag: refs/tags/${{ inputs.tag_string }}
+          tag_name: refs/tags/${{ inputs.tag_string }}
           generate_release_notes: true
           name: ${{ github.ref_name }} Release
 


### PR DESCRIPTION
Git tags are a bit finicky, and with our branch protections it is sort of confusing.

Instead, we can just utilize and manually call this release operation which will then build out a master tag as well as a release with all the correct built binaries in it.