### PR TITLE
Reworking ASP Lib and including Demo Phrases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,9 @@ get_files(copland_am_src
     extracted/Appraisal_Defs.cml
     extracted/Impl_appraisal.cml
     extracted/AM_Json_Interfaces.cml
+    extracted/Flexible_Mechanisms_Vars.cml
+    extracted/Flexible_Mechanisms.cml
+    extracted/Client_AM.cml
     extracted/Server_AM.cml
     util/AM_CLI.sml
 )

--- a/apps/AttestationManager/AM.sml
+++ b/apps/AttestationManager/AM.sml
@@ -40,8 +40,8 @@ fun handleIncoming (listener_and_ac) =
 (* coq_AM_Config -> unit *)
 fun startServer ac =
     let val queueLength = 5 (* TODO: Hardcoded queuelength *)
-        val (Coq_mkAmConfig man clone_uuid aspCb uuidCb pubCb) = ac
-        val (Build_Manifest my_plc _ _ _ _ _ _) = man 
+        val (Coq_mkAmConfig man clone_uuid compatMap aspCb uuidCb pubCb) = ac
+        val (Build_Manifest my_plc _ _ _ _ _) = man 
         val uuid = case uuidCb my_plc of
                       Coq_resultC u => u
                     | Coq_errC s => raise Exception ("UUID lookup error: Could not find own UUID in AM Config")
@@ -59,11 +59,11 @@ fun startServer ac =
 
 (* () -> () *)
 fun main () =
-  let val (manifest, am_lib, aspBin, priv_key) = AM_CLI_Utils.retrieve_CLI_args ()
+  let val (manifest, am_lib, aspBin, priv_key) = AM_CLI_Utils.retrieve_Server_AM_CLI_args ()
       val ac = manifest_compiler manifest am_lib aspBin
       (* Retrieving implicit self place from manifest here *)
-      val (Coq_mkAmConfig man _ _ _ _) = ac 
-      val (Build_Manifest my_plc _ _ _ _ _ _) = man 
+      val (Coq_mkAmConfig man _ _ _ _ _) = ac 
+      val (Build_Manifest my_plc _ _ _ _ _) = man 
       val _ = print ("My Place (retrieved from Manifest): " ^ my_plc ^ "\n\n")
   in
     startServer ac

--- a/apps/AttestationManager/AM.sml
+++ b/apps/AttestationManager/AM.sml
@@ -40,7 +40,7 @@ fun handleIncoming (listener_and_ac) =
 (* coq_AM_Config -> unit *)
 fun startServer ac =
     let val queueLength = 5 (* TODO: Hardcoded queuelength *)
-        val (Coq_mkAmConfig man _ _ _ uuidCb _) = ac 
+        val (Coq_mkAmConfig man clone_uuid aspCb uuidCb pubCb) = ac
         val (Build_Manifest my_plc _ _ _ _ _ _) = man 
         val uuid = case uuidCb my_plc of
                       Coq_resultC u => u
@@ -62,7 +62,7 @@ fun main () =
   let val (manifest, am_lib, aspBin, priv_key) = AM_CLI_Utils.retrieve_CLI_args ()
       val ac = manifest_compiler manifest am_lib aspBin
       (* Retrieving implicit self place from manifest here *)
-      val (Coq_mkAmConfig man _ _ _ _ _) = ac 
+      val (Coq_mkAmConfig man _ _ _ _) = ac 
       val (Build_Manifest my_plc _ _ _ _ _ _) = man 
       val _ = print ("My Place (retrieved from Manifest): " ^ my_plc ^ "\n\n")
   in

--- a/apps/EvidenceToJson/CMakeLists.txt
+++ b/apps/EvidenceToJson/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+get_files(evidenceToJson_src 
+  ${server_am_src}  
+  EvidenceToJson.sml)
+build_posix_am("evidence_to_json" ${evidenceToJson_src})

--- a/apps/EvidenceToJson/EvidenceToJson.sml
+++ b/apps/EvidenceToJson/EvidenceToJson.sml
@@ -1,8 +1,8 @@
 
   
-fun write_term_to_file (term : coq_Term) (filename : string) =
+fun write_evidence_to_file (term : coq_Evidence) (filename : string) =
   let
-    val (Build_Jsonifiable to_JSON _) = coq_Jsonifiable_Term
+    val (Build_Jsonifiable to_JSON _) = coq_Jsonifiable_Evidence
     val coq_json = to_JSON term
     val json_str = coq_JSON_to_string coq_json
   in
@@ -27,14 +27,18 @@ fun main () =
         let val termName  = List.nth argList (termInd + 1) 
             val outFile   = List.nth argList (outFileInd + 1)
             val outTerm   = case termName of
+                              "filehash"    => filehash_demo_evidence_type
+                            | _ => raise (Exception ("TermToJson Argument Error: \n" ^ usage))
+                          (*
                               "cert"        => certificate_style
                             | "bg"          => background_check
                             | "parmut"      => parallel_mutual_1
                             | "layered_bg"  => layered_background_check
                             | "filehash"    => filehash_auth_phrase
                             | _ => raise (Exception ("TermToJson Argument Error: \n" ^ usage))
+                          *)
         in
-          write_term_to_file outTerm outFile
+          write_evidence_to_file outTerm outFile
         end
     end
     handle Exception e => TextIO.print_err e 

--- a/apps/ManifestGenerator/ManifestGenerator.sml
+++ b/apps/ManifestGenerator/ManifestGenerator.sml
@@ -1,7 +1,7 @@
 (* Depends on: util, copland, am/Measurements, am/ServerAm *)
 
 structure ManGen_CLI_Utils = struct
-  type ManGenArgs = (coq_Evidence_Plc_list * coq_Term_Plc_list * string)
+  type ManGenArgs = (coq_Evidence_Plc_list * coq_Term_Plc_list * coq_AM_Library * string)
 
   (* Parse a JSON file into a coq_Evidence_Plc_list *)
   (* : string -> (coq_Evidence_Plc_list, string) coq_ResultT *)
@@ -40,6 +40,24 @@ structure ManGen_CLI_Utils = struct
             from_JSON js
           end
     end
+  
+  (* Parse a JSON file into a coq_AM_Library *)
+  (* : string -> (coq_AM_Library, string) coq_ResultT *)
+  fun parse_am_lib_from_file (filename : string) =
+    let
+      val file_text = TextIOExtra.readFile filename
+    in
+      case (Json.parse file_text) of
+        Err c => Coq_errC c
+      | Ok js => 
+        case (cakeML_JSON_to_coq_JSON js) of
+          Coq_errC c => Coq_errC c
+        | Coq_resultC js =>
+          let val (Build_Jsonifiable _ from_JSON) = coq_Jsonifiable_AM_Library
+          in
+            from_JSON js
+          end
+    end
 
 
     (**
@@ -48,23 +66,26 @@ structure ManGen_CLI_Utils = struct
     *)
   fun retrieve_CLI_args () =
       (let val name = CommandLine.name()
-          val usage = ("Usage: " ^ name ^ " -t <terms_file>.json -e <evidences_file>.json -o <output_directory>\n")
+          val usage = ("Usage: " ^ name ^ " -t <terms_file>.json -e <evidences_file>.json -l <am_lib>.json -o <output_directory>\n")
       in
         case (CommandLine.arguments()) of
           argList =>
             let val termFileInd   = ListExtra.find_index argList "-t"
                 val evidFileInd   = ListExtra.find_index argList "-e"
+                val amLibInd      = ListExtra.find_index argList "-l"
                 val outDirInd     = ListExtra.find_index argList "-o"
 
                 val termFileBool  = (termFileInd <> ~1)
                 val evidFileBool  = (evidFileInd <> ~1)
+                val amLibBool     = (amLibInd <> ~1)
                 val outDirBool    = (outDirInd <> ~1)
             in
-              if ((not termFileBool) orelse (not evidFileBool) orelse (not outDirBool))
+              if ((not termFileBool) orelse (not evidFileBool) orelse (not outDirBool) orelse (not amLibBool))
               then (raise (Exception ("Manifest Generator Argument Error: \n" ^ usage)))
               else
                 let val termFile  = List.nth argList (termFileInd + 1) 
                     val evidFile  = List.nth argList (evidFileInd + 1) 
+                    val amLibFile = List.nth argList (amLibInd + 1) 
                     val outDir    = List.nth argList (outDirInd + 1)
                 in
                   (case (parse_ev_list_from_file evidFile) of
@@ -72,7 +93,12 @@ structure ManGen_CLI_Utils = struct
                   | Coq_resultC evs =>
                     (case (parse_term_list_from_file termFile) of
                       Coq_errC c => raise (Exception ("Error parsing term file: " ^ c))
-                    | Coq_resultC terms => (evs, terms, outDir)))
+                    | Coq_resultC terms => 
+                      (case (parse_am_lib_from_file amLibFile) of
+                        Coq_errC c => raise (Exception ("Error parsing AM Library file: " ^ c))
+                      | Coq_resultC al => (evs, terms, al, outDir))
+                    )
+                  )
                 end
             end
       end) : ManGenArgs
@@ -94,13 +120,15 @@ fun write_out_manifests (out_dir : string) (env_list : coq_EnvironmentM) =
     ) env_list
 
 fun main () =
-    let val (evid_list, term_list, out_path) = ManGen_CLI_Utils.retrieve_CLI_args ()
+    let val (evid_list, term_list, amLib, out_path) = ManGen_CLI_Utils.retrieve_CLI_args ()
         val _ = print "Manifest Generator CLI Args Retrieved\n"
 
-        val environment = end_to_end_mangen evid_list term_list
+        val environment = end_to_end_mangen evid_list term_list amLib
         val _ = print "Manifests Generated\n"
 
-        val _ = write_out_manifests out_path environment
+        val _ = case environment of
+                  Coq_errC e => raise (Exception e)
+                | Coq_resultC res => write_out_manifests out_path res
         val _ = print "Manifests Written to File\n"
     in
       ()

--- a/apps/client_am/CMakeLists.txt
+++ b/apps/client_am/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+get_files(client_am_src ${server_am_src} client_am.sml)
+build_posix_am("client_am" ${client_am_src})

--- a/apps/client_am/client_am.sml
+++ b/apps/client_am/client_am.sml
@@ -59,14 +59,21 @@ fun startServer ac =
 
 (* () -> () *)
 fun main () =
-  let val (manifest, am_lib, aspBin, priv_key) = AM_CLI_Utils.retrieve_CLI_args ()
-      val ac = manifest_compiler manifest am_lib aspBin
-      (* Retrieving implicit self place from manifest here *)
-      val (Coq_mkAmConfig man _ _ _ _) = ac 
-      val (Build_Manifest my_plc _ _ _ _ _ _) = man 
-      val _ = print ("My Place (retrieved from Manifest): " ^ my_plc ^ "\n\n")
-  in
-    startServer ac
+  let val (manifest, term) = AM_CLI_Utils.retrieve_Client_AM_CLI_args ()
+      val demo_term : coq_Term = filehash_auth_phrase
+      val top_plc   : coq_Plc = "TOP_PLC"
+      val att_plc   : coq_Plc = "P0" 
+      val et        : coq_Evidence = Coq_nn O 
+      val init_rawev : coq_RawEv = [passed_bs]
+      val attester_addr : coq_UUID = "localhost:5000"
+      val appraiser_addr : coq_UUID = "localhost:5003" 
+      
+      val app_result = run_demo_client_AM demo_term top_plc att_plc et init_rawev attester_addr appraiser_addr 
+  in 
+    ()
   end
+  handle Exception e => TextIO.print_err e 
+          | Word8Extra.InvalidHex => TextIO.print_err "BSTRING UNSHOW ERROR"
+          | _          => TextIO.print_err "Fatal: unknown error!\n"
 
 val () = main ()

--- a/apps/client_am/client_am.sml
+++ b/apps/client_am/client_am.sml
@@ -8,58 +8,11 @@ When things go well, handle_AM_request returns a string response that holds an
 When things go wrong, handle_AM_request returns a raw error message string. 
   In the future, we may want to wrap said error messages in JSON as well to make 
   it easier on the client. *)
-fun respondToMsg client nonce ac = 
-  let val inString  = Socket.inputAll client 
-      val _ = print ("\n\nReceived request string: \n" ^ inString ^ "\n")
-      (* val jsonTest = case string_to_JSON inString of
-              Coq_errC msg => raise (Exception ("Error in JSON conversion " ^ msg))
-            | Coq_resultC js => coq_JSON_to_string js
-      val _ = print "TEsting json conversion\n"
-      val _ = print ("jsonTest: " ^ jsonTest ^ "\n") *)
-      val outString = handle_AM_request inString ac nonce
-      val _ = print ("\n\nSending response string: \n" ^ outString) 
-  in 
-    Socket.output client outString
-  end
-  handle Json.Exn s1 s2 =>
-          (TextIO.print_err ("JSON error" ^ s1 ^ ": " ^ s2 ^ "\n"); ())
-            
-fun handleIncoming (listener_and_ac) =
-    let val (listener, ac) = listener_and_ac
-        val client = Socket.accept listener
-        val _ = TextIOExtra.printLn "Accepted connection\n"
-        val nonceval = passed_bs (* BString.fromString "anonce" *) (* TODO: should this be hardcoded here? *)
-    in 
-      (respondToMsg client nonceval ac);
-      Socket.close client
-    end
-    handle Socket.Err s     => TextIOExtra.printLn_err ("Socket failure: " ^ s)
-         | Socket.InvalidFD => TextIOExtra.printLn_err "Invalid file descriptor"
-
-
-(* coq_AM_Config -> unit *)
-fun startServer ac =
-    let val queueLength = 5 (* TODO: Hardcoded queuelength *)
-        val (Coq_mkAmConfig man clone_uuid aspCb uuidCb pubCb) = ac
-        val (Build_Manifest my_plc _ _ _ _ _ _) = man 
-        val uuid = case uuidCb my_plc of
-                      Coq_resultC u => u
-                    | Coq_errC s => raise Exception ("UUID lookup error: Could not find own UUID in AM Config")
-        val (ip, port) = decodeUUID uuid
-        val _ = TextIOExtra.printLn ("Starting up Server")
-        val _ = TextIOExtra.printLn ("On port: " ^ (Int.toString port) ^ "\nQueue Length: " ^ (Int.toString queueLength))
-    in 
-     loop handleIncoming ((Socket.listen port queueLength), ac)
-    end
-    handle Socket.Err s => TextIO.print_err ("Socket failure on listener instantiation: " ^ s ^ "\n")
-         | Exception s => TextIO.print_err ("EXCEPTION: " ^ s ^ "\n")
-         | Json.Exn s1 s2 => TextIO.print_err ("Json Exception: " ^ s1 ^ "\n" ^ s2 ^ "\n")
-         | Result.Exn => TextIO.print_err ("Result Exn:\n")
-         | Undef => TextIO.print_err ("Undefined Exception:\n")
 
 (* () -> () *)
 fun main () =
-  let val (manifest, term) = AM_CLI_Utils.retrieve_Client_AM_CLI_args ()
+  let val _ = AM_CLI_Utils.retrieve_Client_AM_CLI_args ()
+      (* Maybe someday we tak args *)
       val demo_term : coq_Term = filehash_auth_phrase
       val top_plc   : coq_Plc = "TOP_PLC"
       val att_plc   : coq_Plc = "P0" 

--- a/do_extract.sh
+++ b/do_extract.sh
@@ -4,8 +4,12 @@
 #   point to the src folder of your local copland-avm Coq development:
 #   i.e:  export COPLAND_AVM_DIR="<your-path>/copland-avm/src"
 
+# Get the directory of the script
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-CML_DIR="./extracted"
+REPO_ROOT=$SCRIPT_DIR
+
+CML_DIR=$REPO_ROOT/extracted
 
 if [ -n "${COPLAND_AVM_DIR}" ]; then
   rm ${CML_DIR}/*.cml

--- a/extracted/Appraisal_Defs.cml
+++ b/extracted/Appraisal_Defs.cml
@@ -12,7 +12,7 @@ fun check_et_size et ls =
 
 fun decrypt_bs_to_rawev bs params ac =
   let val Coq_asp_paramsC _ _ p _ = params in
-  (case let val Coq_mkAmConfig _ _ _ _ pubKeyCb = ac in pubKeyCb p end of
+  (case let val Coq_mkAmConfig _ _ _ _ _ pubKeyCb = ac in pubKeyCb p end of
      Coq_errC e => Coq_errC e
    | Coq_resultC pubkey => decrypt_bs_to_rawev_prim bs params pubkey) end
 
@@ -39,13 +39,22 @@ fun checkNonce' nid nonceCandidate =
     coq_DispatcherErrors) coq_ResultT **)
 
 fun check_asp_EXTD params ls ac =
-  let val Coq_mkAmConfig _ _ aspCb _ _ = ac in aspCb params ls end
+  let val Coq_mkAmConfig _ _ _ aspCb _ _ = ac in aspCb params ls end
 
 (** val check_asp_EXTD' :
     coq_ASP_PARAMS -> coq_Plc -> coq_RawEv -> coq_RawEv -> coq_RawEv coq_AM **)
 
 fun check_asp_EXTD' params _ sig0 ls =
+  let val Coq_asp_paramsC att_id args targ targid = params in
   bind get_AM_amConfig (fn ac =>
-    case check_asp_EXTD params (app sig0 ls) ac of
-      Coq_errC e => am_failm (Coq_am_dispatch_error e)
-    | Coq_resultC r => ret r)
+    case map_get coq_Eq_Class_ID_Type
+           (let val Coq_mkAmConfig _ _ aSP_to_APPR_ASP_Map _ _ _ = ac in
+            aSP_to_APPR_ASP_Map end) att_id of
+      Some appr_asp =>
+      (case check_asp_EXTD (Coq_asp_paramsC appr_asp args targ targid)
+              (app sig0 ls) ac of
+         Coq_errC e => am_failm (Coq_am_dispatch_error e)
+       | Coq_resultC r => ret r)
+    | None =>
+      am_failm (Coq_am_dispatch_error (Runtime
+        "We made it to appraisal without a translation for our attestation ASP"))) end

--- a/extracted/Appraisal_Defs.cml
+++ b/extracted/Appraisal_Defs.cml
@@ -12,7 +12,7 @@ fun check_et_size et ls =
 
 fun decrypt_bs_to_rawev bs params ac =
   let val Coq_asp_paramsC _ _ p _ = params in
-  (case let val Coq_mkAmConfig _ _ _ _ _ pubKeyCb = ac in pubKeyCb p end of
+  (case let val Coq_mkAmConfig _ _ _ _ pubKeyCb = ac in pubKeyCb p end of
      Coq_errC e => Coq_errC e
    | Coq_resultC pubkey => decrypt_bs_to_rawev_prim bs params pubkey) end
 
@@ -39,7 +39,7 @@ fun checkNonce' nid nonceCandidate =
     coq_DispatcherErrors) coq_ResultT **)
 
 fun check_asp_EXTD params ls ac =
-  let val Coq_mkAmConfig _ _ _ app_aspCb _ _ = ac in app_aspCb params ls end
+  let val Coq_mkAmConfig _ _ aspCb _ _ = ac in aspCb params ls end
 
 (** val check_asp_EXTD' :
     coq_ASP_PARAMS -> coq_Plc -> coq_RawEv -> coq_RawEv -> coq_RawEv coq_AM **)

--- a/extracted/Client_AM.cml
+++ b/extracted/Client_AM.cml
@@ -1,0 +1,55 @@
+(** val am_sendReq :
+    coq_Plc -> coq_Term -> coq_UUID -> coq_RawEv -> (coq_RawEv, string)
+    coq_ResultT **)
+
+fun am_sendReq req_plc t uuid e =
+  let val req = Coq_mkPRReq t req_plc e in
+  let val js = coq_ProtocolRunRequest_to_JSON req in
+  let val resp_res = make_JSON_Network_Request uuid js in
+  (case resp_res of
+     Coq_errC msg => Coq_errC msg
+   | Coq_resultC js_res =>
+     (case coq_JSON_to_ProtocolRunResponse js_res of
+        Coq_errC msg => Coq_errC msg
+      | Coq_resultC res =>
+        let val Coq_mkPRResp success ev = res in
+        (case success of
+           True => Coq_resultC ev
+         | False => Coq_errC errStr_remote_am_failure) end)) end end end
+
+(** val am_sendReq_app :
+    coq_UUID -> coq_Term -> coq_Plc -> coq_Evidence -> coq_RawEv ->
+    (coq_AppResultC, string) coq_ResultT **)
+
+fun am_sendReq_app uuid t p e ev =
+  let val req = Coq_mkPAReq t p e ev in
+  let val js = coq_ProtocolAppraiseRequest_to_JSON req in
+  let val resp_res = make_JSON_Network_Request uuid js in
+  (case resp_res of
+     Coq_errC msg => Coq_errC msg
+   | Coq_resultC js_res =>
+     (case coq_JSON_to_ProtocolAppraiseResponse js_res of
+        Coq_errC msg => Coq_errC msg
+      | Coq_resultC res =>
+        let val Coq_mkPAResp success result = res in
+        (case success of
+           True => Coq_resultC result
+         | False => Coq_errC errStr_remote_am_failure) end)) end end end
+
+(** val run_appraisal_client :
+    coq_Term -> coq_Plc -> coq_Evidence -> coq_RawEv -> coq_UUID ->
+    (coq_AppResultC, string) coq_ResultT **)
+
+fun run_appraisal_client t p et re addr =
+  am_sendReq_app addr t p et re
+
+(** val run_demo_client_AM :
+    coq_Term -> coq_Plc -> coq_Plc -> coq_Evidence -> coq_RawEv -> coq_UUID
+    -> coq_UUID -> (coq_AppResultC, string) coq_ResultT **)
+
+fun run_demo_client_AM t top_plc att_plc et re attester_addr appraiser_addr =
+  let val att_result = am_sendReq top_plc t attester_addr re in
+  (case att_result of
+     Coq_errC msg => Coq_errC msg
+   | Coq_resultC att_rawev =>
+     run_appraisal_client t att_plc et att_rawev appraiser_addr) end

--- a/extracted/CvmJson_Interfaces.cml
+++ b/extracted/CvmJson_Interfaces.cml
@@ -79,6 +79,26 @@ fun coq_JSON_to_ProtocolNegotiateResponse resp =
          from_JSON temp_term end) (fn term => Coq_resultC (Coq_mkPNResp
         temp_success term))))
 
+(** val coq_ProtocolAppraiseRequest_to_JSON :
+    coq_ProtocolAppraiseRequest -> coq_JSON **)
+
+fun coq_ProtocolAppraiseRequest_to_JSON req =
+  JSON_Object ((coq_STR_TYPE, (InJSON_String
+    coq_STR_REQUEST)) :: ((coq_STR_ACTION, (InJSON_String
+    coq_STR_APPRAISE)) :: ((coq_STR_TERM, (InJSON_Object
+    (let val Build_Jsonifiable to_JSON _ = coq_Jsonifiable_Term in
+     to_JSON (let val Coq_mkPAReq pareq_term _ _ _ = req in pareq_term end) end))) :: ((coq_STR_REQ_PLC,
+    (InJSON_String
+    (let val Build_Stringifiable to_string _ = coq_Stringifiable_ID_Type in
+     to_string (let val Coq_mkPAReq _ pareq_plc _ _ = req in pareq_plc end) end))) :: ((coq_STR_EVIDENCE,
+    (InJSON_Object
+    (let val Build_Jsonifiable to_JSON _ = coq_Jsonifiable_Evidence in
+     to_JSON
+       (let val Coq_mkPAReq _ _ pareq_evidence _ = req in pareq_evidence end) end))) :: ((coq_STR_RAWEV,
+    (InJSON_Object
+    (let val Build_Jsonifiable to_JSON _ = coq_Jsonifiable_RawEv in
+     to_JSON (let val Coq_mkPAReq _ _ _ pareq_ev = req in pareq_ev end) end))) :: []))))))
+
 (** val coq_JSON_to_ProtocolAppraiseRequest :
     coq_JSON -> (coq_ProtocolAppraiseRequest, string) coq_ResultT **)
 

--- a/extracted/Cvm_Monad.cml
+++ b/extracted/Cvm_Monad.cml
@@ -25,7 +25,7 @@ val get_pl : coq_Plc coq_CVM =
   bind get_CVM_amConfig (fn ac =>
     ret
       (let val Build_Manifest my_abstract_plc _ _ _ _ _ _ =
-         let val Coq_mkAmConfig absMan _ _ _ _ _ = ac in absMan end
+         let val Coq_mkAmConfig absMan _ _ _ _ = ac in absMan end
        in
        my_abstract_plc end))
 
@@ -90,7 +90,7 @@ fun fwd_asp fwd rwev e p ps =
 
 fun do_asp params e _ =
   bind get_CVM_amConfig (fn ac =>
-    case let val Coq_mkAmConfig _ _ aspCb _ _ _ = ac in aspCb params e end of
+    case let val Coq_mkAmConfig _ _ aspCb _ _ = ac in aspCb params e end of
       Coq_errC e0 => failm (Coq_dispatch_error e0)
     | Coq_resultC r => ret r)
 
@@ -171,7 +171,7 @@ val get_cvm_policy : coq_PolicyT coq_CVM =
   bind get_CVM_amConfig (fn ac =>
     ret
       (let val Build_Manifest _ _ _ _ _ _ policy =
-         let val Coq_mkAmConfig absMan _ _ _ _ _ = ac in absMan end
+         let val Coq_mkAmConfig absMan _ _ _ _ = ac in absMan end
        in
        policy end))
 
@@ -190,14 +190,14 @@ fun check_cvm_policy t pTo et =
 
 fun do_remote t pTo e ac =
   let val remote_uuid_res =
-    let val Coq_mkAmConfig _ _ _ _ plcCb _ = ac in plcCb pTo end
+    let val Coq_mkAmConfig _ _ _ plcCb _ = ac in plcCb pTo end
   in
   (case remote_uuid_res of
      Coq_errC e0 => Coq_errC e0
    | Coq_resultC uuid =>
      let val my_plc =
        let val Build_Manifest my_abstract_plc _ _ _ _ _ _ =
-         let val Coq_mkAmConfig absMan _ _ _ _ _ = ac in absMan end
+         let val Coq_mkAmConfig absMan _ _ _ _ = ac in absMan end
        in
        my_abstract_plc end
      in

--- a/extracted/Cvm_Monad.cml
+++ b/extracted/Cvm_Monad.cml
@@ -24,8 +24,8 @@ val get_CVM_amConfig : coq_AM_Config coq_CVM =
 val get_pl : coq_Plc coq_CVM =
   bind get_CVM_amConfig (fn ac =>
     ret
-      (let val Build_Manifest my_abstract_plc _ _ _ _ _ _ =
-         let val Coq_mkAmConfig absMan _ _ _ _ = ac in absMan end
+      (let val Build_Manifest my_abstract_plc _ _ _ _ _ =
+         let val Coq_mkAmConfig absMan _ _ _ _ _ = ac in absMan end
        in
        my_abstract_plc end))
 
@@ -90,7 +90,7 @@ fun fwd_asp fwd rwev e p ps =
 
 fun do_asp params e _ =
   bind get_CVM_amConfig (fn ac =>
-    case let val Coq_mkAmConfig _ _ aspCb _ _ = ac in aspCb params e end of
+    case let val Coq_mkAmConfig _ _ _ aspCb _ _ = ac in aspCb params e end of
       Coq_errC e0 => failm (Coq_dispatch_error e0)
     | Coq_resultC r => ret r)
 
@@ -170,8 +170,8 @@ fun tag_RPY p q e =
 val get_cvm_policy : coq_PolicyT coq_CVM =
   bind get_CVM_amConfig (fn ac =>
     ret
-      (let val Build_Manifest _ _ _ _ _ _ policy =
-         let val Coq_mkAmConfig absMan _ _ _ _ = ac in absMan end
+      (let val Build_Manifest _ _ _ _ _ policy =
+         let val Coq_mkAmConfig absMan _ _ _ _ _ = ac in absMan end
        in
        policy end))
 
@@ -190,14 +190,14 @@ fun check_cvm_policy t pTo et =
 
 fun do_remote t pTo e ac =
   let val remote_uuid_res =
-    let val Coq_mkAmConfig _ _ _ plcCb _ = ac in plcCb pTo end
+    let val Coq_mkAmConfig _ _ _ _ plcCb _ = ac in plcCb pTo end
   in
   (case remote_uuid_res of
      Coq_errC e0 => Coq_errC e0
    | Coq_resultC uuid =>
      let val my_plc =
-       let val Build_Manifest my_abstract_plc _ _ _ _ _ _ =
-         let val Coq_mkAmConfig absMan _ _ _ _ = ac in absMan end
+       let val Build_Manifest my_abstract_plc _ _ _ _ _ =
+         let val Coq_mkAmConfig absMan _ _ _ _ _ = ac in absMan end
        in
        my_abstract_plc end
      in

--- a/extracted/EqClass.cml
+++ b/extracted/EqClass.cml
@@ -23,17 +23,3 @@ val str_eq_class : string coq_EqClass =
 
 val nat_EqClass : nat coq_EqClass =
   Nat.eqb
-
-(** val eqbPair :
-    'a1 coq_EqClass -> 'a2 coq_EqClass -> ('a1 * 'a2) -> ('a1 * 'a2) -> bool **)
-
-fun eqbPair h h' p1 p2 =
-  let val (a1, b1) = p1 in
-  let val (a2, b2) = p2 in
-  (fn x => fn y => x andalso y) (eqb h a1 a2) (eqb h' b1 b2) end end
-
-(** val pair_EqClass :
-    'a1 coq_EqClass -> 'a2 coq_EqClass -> ('a1 * 'a2) coq_EqClass **)
-
-val pair_EqClass =
-  eqbPair

--- a/extracted/Flexible_Mechanisms.cml
+++ b/extracted/Flexible_Mechanisms.cml
@@ -42,7 +42,23 @@ val layered_background_check : coq_Term =
     (Coq_lseq (Coq_asp (ASPC ALL (EXTD (S O)) (Coq_asp_paramsC appraise_id []
     coq_P2 it_targ))) (Coq_asp (ASPC ALL (EXTD (S O)) sig_params)))))))
 
+(** val filehash_auth_phrase : coq_Term **)
+
+val filehash_auth_phrase : coq_Term =
+  Coq_att coq_P1 (Coq_lseq (Coq_asp (ASPC ALL (EXTD (S O)) (Coq_asp_paramsC
+    hashfile_id [] coq_P1 hashfile_targ))) (Coq_asp SIG))
+
+(** val filehash_demo_evidence_type : coq_Evidence **)
+
+val filehash_demo_evidence_type : coq_Evidence =
+  eval filehash_auth_phrase coq_P0 (Coq_nn O)
+
 (** val flexible_mechanisms : coq_Term list **)
 
 val flexible_mechanisms : coq_Term list =
-  certificate_style :: (background_check :: (parallel_mutual_1 :: (parallel_mutual_2 :: (layered_background_check :: []))))
+  certificate_style :: (background_check :: (parallel_mutual_1 :: (parallel_mutual_2 :: (layered_background_check :: (filehash_auth_phrase :: [])))))
+
+(** val flexible_mechanisms_evidence : coq_Evidence list **)
+
+val flexible_mechanisms_evidence : coq_Evidence list =
+  filehash_demo_evidence_type :: []

--- a/extracted/Flexible_Mechanisms_Vars.cml
+++ b/extracted/Flexible_Mechanisms_Vars.cml
@@ -38,6 +38,11 @@ val appraise_id : coq_ASP_ID =
 val certificate_id : coq_ASP_ID =
   "certificate_id"
 
+(** val hashfile_id : coq_ASP_ID **)
+
+val hashfile_id : coq_ASP_ID =
+  "hashfile_id"
+
 (** val sys_targ : coq_TARG_ID **)
 
 val sys_targ : coq_TARG_ID =
@@ -52,3 +57,8 @@ val att_targ : coq_TARG_ID =
 
 val it_targ : coq_TARG_ID =
   "it_targ"
+
+(** val hashfile_targ : coq_TARG_ID **)
+
+val hashfile_targ : coq_TARG_ID =
+  "hashfile_targ"

--- a/extracted/IO_Stubs.cml
+++ b/extracted/IO_Stubs.cml
@@ -6,11 +6,11 @@ val make_JSON_Network_Request : (coq_UUID -> coq_JSON -> (coq_JSON, string)
   failwith "AXIOM TO BE REALIZED"
 
 (** val make_JSON_FS_Location_Request :
-    coq_FS_Location -> coq_ASP_ID -> coq_JSON -> (coq_JSON, string)
+    coq_FS_Location -> coq_Concrete_ASP_ID -> coq_JSON -> (coq_JSON, string)
     coq_ResultT **)
 
-val make_JSON_FS_Location_Request : (coq_FS_Location -> coq_ASP_ID ->
-                                    coq_JSON -> (coq_JSON, string)
+val make_JSON_FS_Location_Request : (coq_FS_Location -> coq_Concrete_ASP_ID
+                                    -> coq_JSON -> (coq_JSON, string)
                                     coq_ResultT) =
   failwith "AXIOM TO BE REALIZED"
 

--- a/extracted/Manifest.cml
+++ b/extracted/Manifest.cml
@@ -18,9 +18,9 @@ val empty_PolicyT : coq_PolicyT =
   []
 
 datatype coq_Manifest =
-  Build_Manifest coq_Plc (coq_ASP_ID manifest_set)
-   ((coq_Plc * coq_ASP_ID) manifest_set) (coq_Plc manifest_set)
-   (coq_Plc manifest_set) (coq_Plc manifest_set) coq_PolicyT
+  Build_Manifest coq_Plc (coq_ASP_ID manifest_set) (coq_ASP_ID manifest_set)
+   (coq_Plc manifest_set) (coq_Plc manifest_set) (coq_Plc manifest_set)
+   coq_PolicyT
 
 (** val empty_Manifest : coq_Manifest **)
 
@@ -29,9 +29,10 @@ val empty_Manifest : coq_Manifest =
     manifest_set_empty manifest_set_empty manifest_set_empty empty_PolicyT
 
 datatype coq_AM_Library =
-  Build_AM_Library coq_UUID ((coq_Plc, coq_UUID) coq_MapC)
-   ((coq_Plc, coq_PublicKey) coq_MapC)
+  Build_AM_Library coq_UUID ((coq_ASP_ID, coq_Concrete_ASP_ID) coq_MapC)
+   ((coq_Plc, coq_UUID) coq_MapC) ((coq_Plc, coq_PublicKey) coq_MapC)
+   ((coq_ASP_ID, coq_ASP_ID) coq_MapC)
 
 datatype coq_AM_Config =
   Coq_mkAmConfig coq_Manifest coq_UUID (coq_DispatcherErrors coq_ASPCallback)
-   (coq_DispatcherErrors coq_ASPCallback) coq_PlcCallback coq_PubKeyCallback
+   coq_PlcCallback coq_PubKeyCallback

--- a/extracted/Manifest.cml
+++ b/extracted/Manifest.cml
@@ -18,15 +18,14 @@ val empty_PolicyT : coq_PolicyT =
   []
 
 datatype coq_Manifest =
-  Build_Manifest coq_Plc (coq_ASP_ID manifest_set) (coq_ASP_ID manifest_set)
-   (coq_Plc manifest_set) (coq_Plc manifest_set) (coq_Plc manifest_set)
-   coq_PolicyT
+  Build_Manifest coq_Plc (coq_ASP_ID manifest_set) (coq_Plc manifest_set)
+   (coq_Plc manifest_set) (coq_Plc manifest_set) coq_PolicyT
 
 (** val empty_Manifest : coq_Manifest **)
 
 val empty_Manifest : coq_Manifest =
   Build_Manifest empty_Manifest_Plc manifest_set_empty manifest_set_empty
-    manifest_set_empty manifest_set_empty manifest_set_empty empty_PolicyT
+    manifest_set_empty manifest_set_empty empty_PolicyT
 
 datatype coq_AM_Library =
   Build_AM_Library coq_UUID ((coq_ASP_ID, coq_Concrete_ASP_ID) coq_MapC)
@@ -34,5 +33,5 @@ datatype coq_AM_Library =
    ((coq_ASP_ID, coq_ASP_ID) coq_MapC)
 
 datatype coq_AM_Config =
-  Coq_mkAmConfig coq_Manifest coq_UUID (coq_DispatcherErrors coq_ASPCallback)
-   coq_PlcCallback coq_PubKeyCallback
+  Coq_mkAmConfig coq_Manifest coq_UUID ((coq_ASP_ID, coq_ASP_ID) coq_MapC)
+   (coq_DispatcherErrors coq_ASPCallback) coq_PlcCallback coq_PubKeyCallback

--- a/extracted/Manifest_Admits.cml
+++ b/extracted/Manifest_Admits.cml
@@ -1,5 +1,13 @@
 type coq_FS_Location (* AXIOM TO BE REALIZED *)
 
+type coq_Concrete_ASP_ID (* AXIOM TO BE REALIZED *)
+
+(** val coq_Stringifiable_Concrete_ASP_ID :
+    coq_Concrete_ASP_ID coq_Stringifiable **)
+
+val coq_Stringifiable_Concrete_ASP_ID : coq_Concrete_ASP_ID coq_Stringifiable =
+  failwith "AXIOM TO BE REALIZED"
+
 type coq_UUID (* AXIOM TO BE REALIZED *)
 
 (** val coq_Stringifiable_UUUID : coq_UUID coq_Stringifiable **)

--- a/extracted/Manifest_Compiler.cml
+++ b/extracted/Manifest_Compiler.cml
@@ -12,64 +12,54 @@ fun minify_mapD hA hB m f =
      | False => minify_mapD hA hB tl f) end
 
 (** val generate_ASP_dispatcher' :
-    coq_Manifest -> coq_FS_Location -> coq_ASP_PARAMS -> coq_RawEv ->
-    (coq_RawEv, coq_DispatcherErrors) coq_ResultT **)
+    coq_Manifest -> coq_AM_Library -> coq_FS_Location -> coq_ASP_PARAMS ->
+    coq_RawEv -> (coq_RawEv, coq_DispatcherErrors) coq_ResultT **)
 
-fun generate_ASP_dispatcher' am aspBin par rawEv =
+fun generate_ASP_dispatcher' am al aspBin par rawEv =
   let val Coq_asp_paramsC aspid args targ_plc targ = par in
   let val asps = let val Build_Manifest _ asps _ _ _ _ _ = am in asps end in
-  (case in_dec_set coq_Eq_Class_ID_Type aspid asps of
-     True =>
-     let val asp_req = Coq_mkASPRReq aspid args targ_plc targ rawEv in
-     let val js_req = coq_ASPRunRequest_to_JSON asp_req in
-     let val resp_res = make_JSON_FS_Location_Request aspBin aspid js_req in
-     (case resp_res of
-        Coq_errC msg => Coq_errC (Runtime msg)
-      | Coq_resultC js_resp =>
-        (case coq_JSON_to_ASPRunResponse js_resp of
-           Coq_errC msg => Coq_errC (Runtime msg)
-         | Coq_resultC r =>
-           let val Coq_mkASPRResp _ bs = r in Coq_resultC bs end)) end end end
-   | False => Coq_errC Unavailable) end end
-
-(** val generate_ASP_dispatcher :
-    coq_ID_Type coq_EqClass -> coq_Manifest -> coq_FS_Location ->
-    coq_DispatcherErrors coq_ASPCallback **)
-
-fun generate_ASP_dispatcher _ =
-  generate_ASP_dispatcher'
-
-(** val generate_appraisal_ASP_dispatcher' :
-    coq_Manifest -> coq_FS_Location -> coq_ASP_PARAMS -> coq_RawEv ->
-    (coq_RawEv, coq_DispatcherErrors) coq_ResultT **)
-
-fun generate_appraisal_ASP_dispatcher' am aspBin par rawEv =
-  let val Coq_asp_paramsC aspid args targ_plc targ = par in
-  let val asps =
+  let val appr_asps =
     let val Build_Manifest _ _ appraisal_asps _ _ _ _ = am in
     appraisal_asps end
   in
-  (case in_dec_set (pair_EqClass coq_Eq_Class_ID_Type coq_Eq_Class_ID_Type)
-          (targ_plc, aspid) asps of
+  let val asp_to_concrete_map =
+    let val Build_AM_Library _ lib_ASPs _ _ _ = al in lib_ASPs end
+  in
+  let val is_attest_asp =
+    case in_dec_set coq_Eq_Class_ID_Type aspid asps of
+      True => True
+    | False => False
+  in
+  let val is_appr_asp =
+    case in_dec_set coq_Eq_Class_ID_Type aspid appr_asps of
+      True => True
+    | False => False
+  in
+  (case (fn x => fn y => x orelse y) is_attest_asp is_appr_asp of
      True =>
-     let val asp_req = Coq_mkASPRReq aspid args targ_plc targ rawEv in
-     let val js_req = coq_ASPRunRequest_to_JSON asp_req in
-     let val resp_res = make_JSON_FS_Location_Request aspBin aspid js_req in
-     (case resp_res of
-        Coq_errC msg => Coq_errC (Runtime msg)
-      | Coq_resultC js_resp =>
-        (case coq_JSON_to_ASPRunResponse js_resp of
+     (case map_get coq_Eq_Class_ID_Type asp_to_concrete_map aspid of
+        Some conc_asp_loc =>
+        let val asp_req = Coq_mkASPRReq aspid args targ_plc targ rawEv in
+        let val js_req = coq_ASPRunRequest_to_JSON asp_req in
+        let val resp_res =
+          make_JSON_FS_Location_Request aspBin conc_asp_loc js_req
+        in
+        (case resp_res of
            Coq_errC msg => Coq_errC (Runtime msg)
-         | Coq_resultC r =>
-           let val Coq_mkASPRResp _ ev = r in Coq_resultC ev end)) end end end
-   | False => Coq_errC Unavailable) end end
+         | Coq_resultC js_resp =>
+           (case coq_JSON_to_ASPRunResponse js_resp of
+              Coq_errC msg => Coq_errC (Runtime msg)
+            | Coq_resultC r =>
+              let val Coq_mkASPRResp _ bs = r in Coq_resultC bs end)) end end end
+      | None => Coq_errC Unavailable)
+   | False => Coq_errC Unavailable) end end end end end end
 
-(** val generate_appraisal_ASP_dispatcher :
-    coq_ID_Type coq_EqClass -> coq_Manifest -> coq_FS_Location ->
-    coq_DispatcherErrors coq_ASPCallback **)
+(** val generate_ASP_dispatcher :
+    coq_ID_Type coq_EqClass -> coq_Manifest -> coq_AM_Library ->
+    coq_FS_Location -> coq_DispatcherErrors coq_ASPCallback **)
 
-fun generate_appraisal_ASP_dispatcher _ =
-  generate_appraisal_ASP_dispatcher'
+fun generate_ASP_dispatcher _ =
+  generate_ASP_dispatcher'
 
 (** val generate_Plc_dispatcher :
     coq_ID_Type coq_EqClass -> coq_AM_Library -> coq_Manifest ->
@@ -77,7 +67,7 @@ fun generate_appraisal_ASP_dispatcher _ =
 
 fun generate_Plc_dispatcher hID al am =
   let val local_plc_map =
-    let val Build_AM_Library _ lib_Plcs _ = al in lib_Plcs end
+    let val Build_AM_Library _ _ lib_Plcs _ _ = al in lib_Plcs end
   in
   let val abstract_plcs =
     let val Build_Manifest _ _ _ uuidPlcs _ _ _ = am in uuidPlcs end
@@ -99,7 +89,7 @@ fun generate_Plc_dispatcher hID al am =
 
 fun generate_PubKey_dispatcher hID al am =
   let val local_pubkey_map =
-    let val Build_AM_Library _ _ lib_PubKeys = al in lib_PubKeys end
+    let val Build_AM_Library _ _ _ lib_PubKeys _ = al in lib_PubKeys end
   in
   let val abstract_plcs =
     let val Build_Manifest _ _ _ _ pubKeyPlcs _ _ = am in pubKeyPlcs end
@@ -120,8 +110,7 @@ fun generate_PubKey_dispatcher hID al am =
 
 fun manifest_compiler m al aspBin =
   Coq_mkAmConfig m
-    (let val Build_AM_Library uUID_AM_Clone _ _ = al in uUID_AM_Clone end)
-    (generate_ASP_dispatcher coq_Eq_Class_ID_Type m aspBin)
-    (generate_appraisal_ASP_dispatcher coq_Eq_Class_ID_Type m aspBin)
+    (let val Build_AM_Library uUID_AM_Clone _ _ _ _ = al in uUID_AM_Clone end)
+    (generate_ASP_dispatcher coq_Eq_Class_ID_Type m al aspBin)
     (generate_Plc_dispatcher coq_Eq_Class_ID_Type al m)
     (generate_PubKey_dispatcher coq_Eq_Class_ID_Type al m)

--- a/extracted/Manifest_Compiler.cml
+++ b/extracted/Manifest_Compiler.cml
@@ -17,25 +17,11 @@ fun minify_mapD hA hB m f =
 
 fun generate_ASP_dispatcher' am al aspBin par rawEv =
   let val Coq_asp_paramsC aspid args targ_plc targ = par in
-  let val asps = let val Build_Manifest _ asps _ _ _ _ _ = am in asps end in
-  let val appr_asps =
-    let val Build_Manifest _ _ appraisal_asps _ _ _ _ = am in
-    appraisal_asps end
-  in
+  let val asps = let val Build_Manifest _ asps _ _ _ _ = am in asps end in
   let val asp_to_concrete_map =
     let val Build_AM_Library _ lib_ASPs _ _ _ = al in lib_ASPs end
   in
-  let val is_attest_asp =
-    case in_dec_set coq_Eq_Class_ID_Type aspid asps of
-      True => True
-    | False => False
-  in
-  let val is_appr_asp =
-    case in_dec_set coq_Eq_Class_ID_Type aspid appr_asps of
-      True => True
-    | False => False
-  in
-  (case (fn x => fn y => x orelse y) is_attest_asp is_appr_asp of
+  (case in_dec_set coq_Eq_Class_ID_Type aspid asps of
      True =>
      (case map_get coq_Eq_Class_ID_Type asp_to_concrete_map aspid of
         Some conc_asp_loc =>
@@ -52,7 +38,7 @@ fun generate_ASP_dispatcher' am al aspBin par rawEv =
             | Coq_resultC r =>
               let val Coq_mkASPRResp _ bs = r in Coq_resultC bs end)) end end end
       | None => Coq_errC Unavailable)
-   | False => Coq_errC Unavailable) end end end end end end
+   | False => Coq_errC Unavailable) end end end
 
 (** val generate_ASP_dispatcher :
     coq_ID_Type coq_EqClass -> coq_Manifest -> coq_AM_Library ->
@@ -70,7 +56,7 @@ fun generate_Plc_dispatcher hID al am =
     let val Build_AM_Library _ _ lib_Plcs _ _ = al in lib_Plcs end
   in
   let val abstract_plcs =
-    let val Build_Manifest _ _ _ uuidPlcs _ _ _ = am in uuidPlcs end
+    let val Build_Manifest _ _ uuidPlcs _ _ _ = am in uuidPlcs end
   in
   let val shrunk_map =
     minify_mapD hID coq_Eq_Class_uuid local_plc_map (fn x =>
@@ -92,7 +78,7 @@ fun generate_PubKey_dispatcher hID al am =
     let val Build_AM_Library _ _ _ lib_PubKeys _ = al in lib_PubKeys end
   in
   let val abstract_plcs =
-    let val Build_Manifest _ _ _ _ pubKeyPlcs _ _ = am in pubKeyPlcs end
+    let val Build_Manifest _ _ _ pubKeyPlcs _ _ = am in pubKeyPlcs end
   in
   let val shrunk_map =
     minify_mapD hID coq_Eq_Class_public_key local_pubkey_map (fn x =>
@@ -111,6 +97,8 @@ fun generate_PubKey_dispatcher hID al am =
 fun manifest_compiler m al aspBin =
   Coq_mkAmConfig m
     (let val Build_AM_Library uUID_AM_Clone _ _ _ _ = al in uUID_AM_Clone end)
+    (let val Build_AM_Library _ _ _ _ aSP_Compat_Map = al in
+     aSP_Compat_Map end)
     (generate_ASP_dispatcher coq_Eq_Class_ID_Type m al aspBin)
     (generate_Plc_dispatcher coq_Eq_Class_ID_Type al m)
     (generate_PubKey_dispatcher coq_Eq_Class_ID_Type al m)

--- a/extracted/Manifest_Generator.cml
+++ b/extracted/Manifest_Generator.cml
@@ -2,19 +2,19 @@
     coq_ASP_ID -> coq_Manifest -> coq_Manifest **)
 
 fun aspid_manifest_update i m =
-  let val Build_Manifest oldPlc oldasps old_app_asps oldKnowsOf oldContext
-    oldTargets oldPolicy = m
+  let val Build_Manifest oldPlc oldasps oldKnowsOf oldContext oldTargets
+    oldPolicy = m
   in
   Build_Manifest oldPlc (manset_add coq_Eq_Class_ID_Type i oldasps)
-  old_app_asps oldKnowsOf oldContext oldTargets oldPolicy end
+  oldKnowsOf oldContext oldTargets oldPolicy end
 
 (** val knowsof_manifest_update : coq_Plc -> coq_Manifest -> coq_Manifest **)
 
 fun knowsof_manifest_update toPlc m =
-  let val Build_Manifest oldPlc oldasps old_app_asps oldKnowsOf oldContext
-    oldTargets oldPolicy = m
+  let val Build_Manifest oldPlc oldasps oldKnowsOf oldContext oldTargets
+    oldPolicy = m
   in
-  Build_Manifest oldPlc oldasps old_app_asps
+  Build_Manifest oldPlc oldasps
   (manset_add coq_Eq_Class_ID_Type toPlc oldKnowsOf) oldContext oldTargets
   oldPolicy end
 
@@ -22,35 +22,34 @@ fun knowsof_manifest_update toPlc m =
 
 fun knowsof_myPlc_manifest_update m =
   knowsof_manifest_update
-    (let val Build_Manifest my_abstract_plc _ _ _ _ _ _ = m in
+    (let val Build_Manifest my_abstract_plc _ _ _ _ _ = m in
      my_abstract_plc end) m
 
 (** val myPlc_manifest_update : coq_Plc -> coq_Manifest -> coq_Manifest **)
 
 fun myPlc_manifest_update p m =
-  let val Build_Manifest _ oldasps old_app_asps oldKnowsOf oldContext
-    oldTargets oldPolicy = m
+  let val Build_Manifest _ oldasps oldKnowsOf oldContext oldTargets
+    oldPolicy = m
   in
-  Build_Manifest p oldasps old_app_asps oldKnowsOf oldContext oldTargets
-  oldPolicy end
+  Build_Manifest p oldasps oldKnowsOf oldContext oldTargets oldPolicy end
 
 (** val pubkey_manifest_update : coq_Plc -> coq_Manifest -> coq_Manifest **)
 
 fun pubkey_manifest_update p m =
-  let val Build_Manifest oldPlc oldasps old_app_asps oldKnowsOf oldContext
-    oldTargets oldPolicy = m
+  let val Build_Manifest oldPlc oldasps oldKnowsOf oldContext oldTargets
+    oldPolicy = m
   in
-  Build_Manifest oldPlc oldasps old_app_asps oldKnowsOf
+  Build_Manifest oldPlc oldasps oldKnowsOf
   (manset_add coq_Eq_Class_ID_Type p oldContext) oldTargets oldPolicy end
 
 (** val pubkeys_manifest_update :
     coq_Plc manifest_set -> coq_Manifest -> coq_Manifest **)
 
 fun pubkeys_manifest_update ps m =
-  let val Build_Manifest oldMyPlc oldasps old_app_asps oldKnowsOf oldPubs
-    oldTargets oldPolicy = m
+  let val Build_Manifest oldMyPlc oldasps oldKnowsOf oldPubs oldTargets
+    oldPolicy = m
   in
-  Build_Manifest oldMyPlc oldasps old_app_asps oldKnowsOf
+  Build_Manifest oldMyPlc oldasps oldKnowsOf
   (fold_right (manset_add coq_Eq_Class_ID_Type) oldPubs ps) oldTargets
   oldPolicy end
 
@@ -58,10 +57,10 @@ fun pubkeys_manifest_update ps m =
     coq_Plc -> coq_Plc -> coq_Manifest -> coq_Manifest **)
 
 fun update_manifest_policy_targ targp _ m =
-  let val Build_Manifest oldMyPlc oldasps old_app_asps oldKnowsOf oldContext
-    oldTargets oldPolicy = m
+  let val Build_Manifest oldMyPlc oldasps oldKnowsOf oldContext oldTargets
+    oldPolicy = m
   in
-  Build_Manifest oldMyPlc oldasps old_app_asps oldKnowsOf oldContext
+  Build_Manifest oldMyPlc oldasps oldKnowsOf oldContext
   (manset_add coq_Eq_Class_ID_Type targp oldTargets) oldPolicy end
 
 (** val asp_manifest_update : coq_ASP -> coq_Manifest -> coq_Manifest **)
@@ -78,6 +77,20 @@ fun asp_manifest_update a m =
     let val m' = pubkey_manifest_update p m in
     aspid_manifest_update enc_aspid m' end
   | _ => m
+
+(** val manifest_update_env_res :
+    coq_Plc -> coq_EnvironmentM -> (coq_Manifest -> (coq_Manifest, string)
+    coq_ResultT) -> (coq_EnvironmentM, string) coq_ResultT **)
+
+fun manifest_update_env_res p e f =
+  let val m =
+    case map_get coq_Eq_Class_ID_Type e p of
+      Some mm => mm
+    | None => myPlc_manifest_update p empty_Manifest
+  in
+  (case f m of
+     Coq_errC e0 => Coq_errC e0
+   | Coq_resultC m' => Coq_resultC (map_set coq_Eq_Class_ID_Type e p m')) end
 
 (** val manifest_update_env :
     coq_Plc -> coq_EnvironmentM -> (coq_Manifest -> coq_Manifest) ->
@@ -127,44 +140,56 @@ fun manifest_generator t p =
 fun environment_to_manifest_list e =
   map_vals coq_Eq_Class_ID_Type e
 
-(** val app_aspid_manifest_update :
-    coq_ASP_ID -> coq_Manifest -> coq_Manifest **)
-
-fun app_aspid_manifest_update i m =
-  let val Build_Manifest oldPlc oldasps old_app_asps oldKnowsOf oldContext
-    oldTargets oldPolicy = m
-  in
-  Build_Manifest oldPlc oldasps
-  (manset_add coq_Eq_Class_ID_Type i old_app_asps) oldKnowsOf oldContext
-  oldTargets oldPolicy end
-
 (** val manifest_generator_app'' :
-    coq_Evidence -> coq_Manifest -> coq_Manifest **)
+    coq_Evidence -> coq_AM_Library -> coq_Manifest -> (coq_Manifest, string)
+    coq_ResultT **)
 
-fun manifest_generator_app'' et m =
+fun manifest_generator_app'' et al m =
   case et of
     Coq_uu _ fwd ps e' =>
     (case fwd of
        ENCR =>
-       let val Coq_asp_paramsC _ _ p' _ = ps in
-       manifest_generator_app'' e' (pubkey_manifest_update p' m) end
+       let val Coq_asp_paramsC a _ p' _ = ps in
+       (case map_get coq_Eq_Class_ID_Type
+               (let val Build_AM_Library _ _ _ _ aSP_Compat_Map = al in
+                aSP_Compat_Map end) a of
+          Some a' =>
+          manifest_generator_app'' e' al
+            (aspid_manifest_update a' (pubkey_manifest_update p' m))
+        | None => Coq_errC "Compatible Appraisal ASP not found in AM Library") end
      | EXTD _ =>
        let val Coq_asp_paramsC a _ _ _ = ps in
-       manifest_generator_app'' e' (app_aspid_manifest_update a m) end
-     | KEEP => manifest_generator_app'' e' m
-     | _ => m)
+       (case map_get coq_Eq_Class_ID_Type
+               (let val Build_AM_Library _ _ _ _ aSP_Compat_Map = al in
+                aSP_Compat_Map end) a of
+          Some a' =>
+          manifest_generator_app'' e' al (aspid_manifest_update a' m)
+        | None => Coq_errC "Compatible Appraisal ASP not found in AM Library") end
+     | KEEP =>
+       let val Coq_asp_paramsC a _ _ _ = ps in
+       (case map_get coq_Eq_Class_ID_Type
+               (let val Build_AM_Library _ _ _ _ aSP_Compat_Map = al in
+                aSP_Compat_Map end) a of
+          Some a' =>
+          manifest_generator_app'' e' al (aspid_manifest_update a' m)
+        | None => Coq_errC "Compatible Appraisal ASP not found in AM Library") end
+     | _ => Coq_resultC m)
   | Coq_ss e1 e2 =>
-    manifest_generator_app'' e2 (manifest_generator_app'' e1 m)
-  | _ => m
+    (case manifest_generator_app'' e1 al m of
+       Coq_errC e => Coq_errC e
+     | Coq_resultC m' => manifest_generator_app'' e2 al m')
+  | _ => Coq_resultC m
 
 (** val manifest_generator_app' :
-    coq_Plc -> coq_Evidence -> coq_EnvironmentM -> coq_EnvironmentM **)
+    coq_Plc -> coq_Evidence -> coq_AM_Library -> coq_EnvironmentM ->
+    (coq_EnvironmentM, string) coq_ResultT **)
 
-fun manifest_generator_app' p et env =
-  manifest_update_env p env (manifest_generator_app'' et)
+fun manifest_generator_app' p et al env =
+  manifest_update_env_res p env (manifest_generator_app'' et al)
 
 (** val manifest_generator_app :
-    coq_Evidence -> coq_Plc -> coq_EnvironmentM **)
+    coq_Evidence -> coq_Plc -> coq_AM_Library -> (coq_EnvironmentM, string)
+    coq_ResultT **)
 
-fun manifest_generator_app et p =
-  manifest_generator_app' p et e_empty
+fun manifest_generator_app et p al =
+  manifest_generator_app' p et al e_empty

--- a/extracted/Manifest_Generator.cml
+++ b/extracted/Manifest_Generator.cml
@@ -128,15 +128,15 @@ fun environment_to_manifest_list e =
   map_vals coq_Eq_Class_ID_Type e
 
 (** val app_aspid_manifest_update :
-    coq_ASP_ID -> coq_Plc -> coq_Manifest -> coq_Manifest **)
+    coq_ASP_ID -> coq_Manifest -> coq_Manifest **)
 
-fun app_aspid_manifest_update i p m =
+fun app_aspid_manifest_update i m =
   let val Build_Manifest oldPlc oldasps old_app_asps oldKnowsOf oldContext
     oldTargets oldPolicy = m
   in
   Build_Manifest oldPlc oldasps
-  (manset_add (pair_EqClass coq_Eq_Class_ID_Type coq_Eq_Class_ID_Type) (i, p)
-    old_app_asps) oldKnowsOf oldContext oldTargets oldPolicy end
+  (manset_add coq_Eq_Class_ID_Type i old_app_asps) oldKnowsOf oldContext
+  oldTargets oldPolicy end
 
 (** val manifest_generator_app'' :
     coq_Evidence -> coq_Manifest -> coq_Manifest **)
@@ -149,8 +149,8 @@ fun manifest_generator_app'' et m =
        let val Coq_asp_paramsC _ _ p' _ = ps in
        manifest_generator_app'' e' (pubkey_manifest_update p' m) end
      | EXTD _ =>
-       let val Coq_asp_paramsC a _ targ _ = ps in
-       manifest_generator_app'' e' (app_aspid_manifest_update targ a m) end
+       let val Coq_asp_paramsC a _ _ _ = ps in
+       manifest_generator_app'' e' (app_aspid_manifest_update a m) end
      | KEEP => manifest_generator_app'' e' m
      | _ => m)
   | Coq_ss e1 e2 =>

--- a/extracted/Manifest_Generator_Union.cml
+++ b/extracted/Manifest_Generator_Union.cml
@@ -16,16 +16,21 @@ fun mangen_plcTerm_list_union ls =
   env_list_union (manifest_generator_plcTerm_list ls)
 
 (** val manifest_generator_plcEvidence_list :
-    (coq_Evidence * coq_Plc) list -> coq_EnvironmentM list **)
+    (coq_Evidence * coq_Plc) list -> coq_AM_Library -> (coq_EnvironmentM
+    list, string) coq_ResultT **)
 
-fun manifest_generator_plcEvidence_list ls =
-  map (fn pat => let val (et, p) = pat in manifest_generator_app et p end) ls
+fun manifest_generator_plcEvidence_list ls al =
+  result_map (fn pat =>
+    let val (et, p) = pat in manifest_generator_app et p al end) ls
 
 (** val mangen_plcEvidence_list_union :
-    (coq_Evidence * coq_Plc) list -> coq_EnvironmentM **)
+    (coq_Evidence * coq_Plc) list -> coq_AM_Library -> (coq_EnvironmentM,
+    string) coq_ResultT **)
 
-fun mangen_plcEvidence_list_union ls =
-  env_list_union (manifest_generator_plcEvidence_list ls)
+fun mangen_plcEvidence_list_union ls al =
+  case manifest_generator_plcEvidence_list ls al of
+    Coq_errC e => Coq_errC e
+  | Coq_resultC ls' => Coq_resultC (env_list_union ls')
 
 type coq_Evidence_Plc_list = (coq_Evidence * coq_Plc) list
 
@@ -179,12 +184,15 @@ fun update_pubkeys_env pubs env =
   map (update_pubkeys_env' pubs) env
 
 (** val end_to_end_mangen' :
-    coq_Evidence_Plc_list -> coq_Term_Plc_list -> coq_EnvironmentM **)
+    coq_Evidence_Plc_list -> coq_Term_Plc_list -> coq_AM_Library ->
+    (coq_EnvironmentM, string) coq_ResultT **)
 
-fun end_to_end_mangen' ls ts =
-  let val app_env = mangen_plcEvidence_list_union ls in
+fun end_to_end_mangen' ls ts al =
+  let val app_env = mangen_plcEvidence_list_union ls al in
   let val att_env = mangen_plcTerm_list_union ts in
-  environment_union app_env att_env end end
+  (case app_env of
+     Coq_errC e => Coq_errC e
+   | Coq_resultC app_env0 => Coq_resultC (environment_union app_env0 att_env)) end end
 
 (** val manset_union_list :
     'a1 coq_EqClass -> 'a1 manifest_set manifest_set -> 'a1 manifest_set **)
@@ -204,14 +212,21 @@ fun get_all_unique_places ls ets =
   manset_union coq_Eq_Class_ID_Type ts_ps ets_ps end end end
 
 (** val end_to_end_mangen :
-    coq_Evidence_Plc_list -> coq_Term_Plc_list -> coq_EnvironmentM **)
+    coq_Evidence_Plc_list -> coq_Term_Plc_list -> coq_AM_Library ->
+    (coq_EnvironmentM, string) coq_ResultT **)
 
-fun end_to_end_mangen ls ts =
+fun end_to_end_mangen ls ts al =
   let val ps = get_all_unique_places ts ls in
-  update_pubkeys_env ps (update_knowsOf_myPlc_env (end_to_end_mangen' ls ts)) end
+  (case end_to_end_mangen' ls ts al of
+     Coq_errC e => Coq_errC e
+   | Coq_resultC env =>
+     Coq_resultC (update_pubkeys_env ps (update_knowsOf_myPlc_env env))) end
 
 (** val end_to_end_mangen_final :
-    coq_Evidence_Plc_list -> coq_Term_Plc_list -> coq_Manifest list **)
+    coq_Evidence_Plc_list -> coq_Term_Plc_list -> coq_AM_Library ->
+    (coq_Manifest list, string) coq_ResultT **)
 
-fun end_to_end_mangen_final ls ts =
-  environment_to_manifest_list (end_to_end_mangen ls ts)
+fun end_to_end_mangen_final ls ts al =
+  case end_to_end_mangen ls ts al of
+    Coq_errC e => Coq_errC e
+  | Coq_resultC env => Coq_resultC (environment_to_manifest_list env)

--- a/extracted/Manifest_JSON.cml
+++ b/extracted/Manifest_JSON.cml
@@ -1,17 +1,16 @@
 (** val coq_Manifest_to_JSON : coq_Manifest -> coq_JSON **)
 
 fun coq_Manifest_to_JSON m =
-  let val Build_Manifest my_abstract_plc asps appraisal_asps uuidPlcs
-    pubKeyPlcs targetPlcs policy = m
+  let val Build_Manifest my_abstract_plc asps appr_asps uuidPlcs pubKeyPlcs
+    targetPlcs policy = m
   in
   JSON_Object ((coq_MAN_ABS_PLC, (InJSON_String
   (let val Build_Stringifiable to_string _ = coq_Stringifiable_ID_Type in
    to_string my_abstract_plc end))) :: ((coq_MAN_ASPS, (InJSON_Array
   (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
     asps))) :: ((coq_MAN_APPR_ASPS, (InJSON_Array
-  (manifest_set_pairs_to_list_InJson coq_Stringifiable_ID_Type
-    coq_Stringifiable_ID_Type appraisal_asps))) :: ((coq_MAN_UUUID_PLCS,
-  (InJSON_Array
+  (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
+    appr_asps))) :: ((coq_MAN_UUUID_PLCS, (InJSON_Array
   (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
     uuidPlcs))) :: ((coq_MAN_PUBKEY_PLCS, (InJSON_Array
   (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
@@ -46,10 +45,8 @@ fun coq_JSON_to_Manifest js =
                     (list_InJson_to_manifest_set coq_Stringifiable_ID_Type
                       coq_Eq_Class_ID_Type temp_ASPS) (fn aSPS =>
                     res_bind
-                      (list_InJson_to_manifest_set_pairs
-                        coq_Stringifiable_ID_Type coq_Stringifiable_ID_Type
-                        coq_Eq_Class_ID_Type coq_Eq_Class_ID_Type
-                        temp_APPR_ASPS) (fn aPPR_ASPS =>
+                      (list_InJson_to_manifest_set coq_Stringifiable_ID_Type
+                        coq_Eq_Class_ID_Type temp_APPR_ASPS) (fn aPPR_ASPS =>
                       res_bind
                         (list_InJson_to_manifest_set
                           coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
@@ -79,10 +76,17 @@ val coq_Jsonifiable_Manifest : coq_Manifest coq_Jsonifiable =
 (** val coq_AM_Lib_to_JSON : coq_AM_Library -> coq_JSON **)
 
 fun coq_AM_Lib_to_JSON am =
-  let val Build_AM_Library clone_uuid lib_plcs lib_pubkeys = am in
+  let val Build_AM_Library clone_uuid lib_asps lib_plcs lib_pubkeys
+    compat_asps_map = am
+  in
   JSON_Object ((coq_AM_CLONE_UUUID, (InJSON_String
   (let val Build_Stringifiable to_string _ = coq_Stringifiable_UUUID in
-   to_string clone_uuid end))) :: ((coq_AM_LIB_PLCS, (InJSON_Object
+   to_string clone_uuid end))) :: ((coq_AM_LIB_ASPS, (InJSON_Object
+  (let val Build_Jsonifiable to_JSON _ =
+     jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
+       coq_Eq_Class_ID_Type coq_Stringifiable_Concrete_ASP_ID
+   in
+   to_JSON lib_asps end))) :: ((coq_AM_LIB_PLCS, (InJSON_Object
   (let val Build_Jsonifiable to_JSON _ =
      jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
        coq_Eq_Class_ID_Type coq_Stringifiable_UUUID
@@ -92,7 +96,12 @@ fun coq_AM_Lib_to_JSON am =
      jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
        coq_Eq_Class_ID_Type coq_Stringifiable_PublicKey
    in
-   to_JSON lib_pubkeys end))) :: []))) end
+   to_JSON lib_pubkeys end))) :: ((coq_AM_LIB_COMPAT_ASPS, (InJSON_Object
+  (let val Build_Jsonifiable to_JSON _ =
+     jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
+       coq_Eq_Class_ID_Type coq_Stringifiable_ID_Type
+   in
+   to_JSON compat_asps_map end))) :: []))))) end
 
 (** val coq_JSON_to_AM_Lib :
     coq_JSON -> (coq_AM_Library, string) coq_ResultT **)
@@ -100,26 +109,45 @@ fun coq_AM_Lib_to_JSON am =
 fun coq_JSON_to_AM_Lib js =
   res_bind (coq_JSON_get_string coq_AM_CLONE_UUUID js)
     (fn temp_CLONE_UUUID =>
-    res_bind (coq_JSON_get_Object coq_AM_LIB_PLCS js) (fn temp_LIB_PLCS =>
-      res_bind (coq_JSON_get_Object coq_AM_LIB_PUBKEYS js)
-        (fn temp_LIB_PUBKEYS =>
-        res_bind
-          (let val Build_Stringifiable _ from_string = coq_Stringifiable_UUUID
-           in
-           from_string temp_CLONE_UUUID end) (fn cLONE_UUUID =>
-          res_bind
-            (let val Build_Jsonifiable _ from_JSON =
-               jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
-                 coq_Eq_Class_ID_Type coq_Stringifiable_UUUID
-             in
-             from_JSON temp_LIB_PLCS end) (fn lIB_PLCS =>
+    res_bind (coq_JSON_get_Object coq_AM_LIB_ASPS js) (fn temp_LIB_ASPS =>
+      res_bind (coq_JSON_get_Object coq_AM_LIB_PLCS js) (fn temp_LIB_PLCS =>
+        res_bind (coq_JSON_get_Object coq_AM_LIB_PUBKEYS js)
+          (fn temp_LIB_PUBKEYS =>
+          res_bind (coq_JSON_get_Object coq_AM_LIB_COMPAT_ASPS js)
+            (fn temp_COMPAT_ASPS =>
             res_bind
-              (let val Build_Jsonifiable _ from_JSON =
-                 jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
-                   coq_Eq_Class_ID_Type coq_Stringifiable_PublicKey
+              (let val Build_Stringifiable _ from_string =
+                 coq_Stringifiable_UUUID
                in
-               from_JSON temp_LIB_PUBKEYS end) (fn lIB_PUBKEYS => Coq_resultC
-              (Build_AM_Library cLONE_UUUID lIB_PLCS lIB_PUBKEYS)))))))
+               from_string temp_CLONE_UUUID end) (fn cLONE_UUUID =>
+              res_bind
+                (let val Build_Jsonifiable _ from_JSON =
+                   jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
+                     coq_Eq_Class_ID_Type coq_Stringifiable_Concrete_ASP_ID
+                 in
+                 from_JSON temp_LIB_ASPS end) (fn lIB_ASPS =>
+                res_bind
+                  (let val Build_Jsonifiable _ from_JSON =
+                     jsonifiable_map_serial_serial coq_Stringifiable_ID_Type
+                       coq_Eq_Class_ID_Type coq_Stringifiable_UUUID
+                   in
+                   from_JSON temp_LIB_PLCS end) (fn lIB_PLCS =>
+                  res_bind
+                    (let val Build_Jsonifiable _ from_JSON =
+                       jsonifiable_map_serial_serial
+                         coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
+                         coq_Stringifiable_PublicKey
+                     in
+                     from_JSON temp_LIB_PUBKEYS end) (fn lIB_PUBKEYS =>
+                    res_bind
+                      (let val Build_Jsonifiable _ from_JSON =
+                         jsonifiable_map_serial_serial
+                           coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
+                           coq_Stringifiable_ID_Type
+                       in
+                       from_JSON temp_COMPAT_ASPS end) (fn cOMPAT_ASPS =>
+                      Coq_resultC (Build_AM_Library cLONE_UUUID lIB_ASPS
+                      lIB_PLCS lIB_PUBKEYS cOMPAT_ASPS)))))))))))
 
 (** val coq_Jsonifiable_AM_Library : coq_AM_Library coq_Jsonifiable **)
 

--- a/extracted/Manifest_JSON.cml
+++ b/extracted/Manifest_JSON.cml
@@ -1,16 +1,14 @@
 (** val coq_Manifest_to_JSON : coq_Manifest -> coq_JSON **)
 
 fun coq_Manifest_to_JSON m =
-  let val Build_Manifest my_abstract_plc asps appr_asps uuidPlcs pubKeyPlcs
-    targetPlcs policy = m
+  let val Build_Manifest my_abstract_plc asps uuidPlcs pubKeyPlcs targetPlcs
+    policy = m
   in
   JSON_Object ((coq_MAN_ABS_PLC, (InJSON_String
   (let val Build_Stringifiable to_string _ = coq_Stringifiable_ID_Type in
    to_string my_abstract_plc end))) :: ((coq_MAN_ASPS, (InJSON_Array
   (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
-    asps))) :: ((coq_MAN_APPR_ASPS, (InJSON_Array
-  (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
-    appr_asps))) :: ((coq_MAN_UUUID_PLCS, (InJSON_Array
+    asps))) :: ((coq_MAN_UUUID_PLCS, (InJSON_Array
   (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
     uuidPlcs))) :: ((coq_MAN_PUBKEY_PLCS, (InJSON_Array
   (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
@@ -18,7 +16,7 @@ fun coq_Manifest_to_JSON m =
   (manifest_set_to_list_InJson coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
     targetPlcs))) :: ((coq_MAN_POLICY, (InJSON_Array
   (manifest_set_pairs_to_list_InJson coq_Stringifiable_ID_Type
-    coq_Stringifiable_ID_Type policy))) :: []))))))) end
+    coq_Stringifiable_ID_Type policy))) :: [])))))) end
 
 (** val coq_JSON_to_Manifest :
     coq_JSON -> (coq_Manifest, string) coq_ResultT **)
@@ -26,47 +24,40 @@ fun coq_Manifest_to_JSON m =
 fun coq_JSON_to_Manifest js =
   res_bind (coq_JSON_get_string coq_MAN_ABS_PLC js) (fn temp_ABS_PLC =>
     res_bind (coq_JSON_get_Array coq_MAN_ASPS js) (fn temp_ASPS =>
-      res_bind (coq_JSON_get_Array coq_MAN_APPR_ASPS js)
-        (fn temp_APPR_ASPS =>
-        res_bind (coq_JSON_get_Array coq_MAN_UUUID_PLCS js)
-          (fn temp_UUUID_PLCS =>
-          res_bind (coq_JSON_get_Array coq_MAN_PUBKEY_PLCS js)
-            (fn temp_PUBKEY_PLCS =>
-            res_bind (coq_JSON_get_Array coq_MAN_TARGET_PLCS js)
-              (fn temp_TARGET_PLCS =>
-              res_bind (coq_JSON_get_Array coq_MAN_POLICY js)
-                (fn temp_POLICY =>
+      res_bind (coq_JSON_get_Array coq_MAN_UUUID_PLCS js)
+        (fn temp_UUUID_PLCS =>
+        res_bind (coq_JSON_get_Array coq_MAN_PUBKEY_PLCS js)
+          (fn temp_PUBKEY_PLCS =>
+          res_bind (coq_JSON_get_Array coq_MAN_TARGET_PLCS js)
+            (fn temp_TARGET_PLCS =>
+            res_bind (coq_JSON_get_Array coq_MAN_POLICY js)
+              (fn temp_POLICY =>
+              res_bind
+                (let val Build_Stringifiable _ from_string =
+                   coq_Stringifiable_ID_Type
+                 in
+                 from_string temp_ABS_PLC end) (fn aBS_PLC =>
                 res_bind
-                  (let val Build_Stringifiable _ from_string =
-                     coq_Stringifiable_ID_Type
-                   in
-                   from_string temp_ABS_PLC end) (fn aBS_PLC =>
+                  (list_InJson_to_manifest_set coq_Stringifiable_ID_Type
+                    coq_Eq_Class_ID_Type temp_ASPS) (fn aSPS =>
                   res_bind
                     (list_InJson_to_manifest_set coq_Stringifiable_ID_Type
-                      coq_Eq_Class_ID_Type temp_ASPS) (fn aSPS =>
+                      coq_Eq_Class_ID_Type temp_UUUID_PLCS) (fn uUID_PLCS =>
                     res_bind
                       (list_InJson_to_manifest_set coq_Stringifiable_ID_Type
-                        coq_Eq_Class_ID_Type temp_APPR_ASPS) (fn aPPR_ASPS =>
+                        coq_Eq_Class_ID_Type temp_PUBKEY_PLCS)
+                      (fn pUBKEY_PLCS =>
                       res_bind
                         (list_InJson_to_manifest_set
                           coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
-                          temp_UUUID_PLCS) (fn uUID_PLCS =>
+                          temp_TARGET_PLCS) (fn tARGET_PLCS =>
                         res_bind
-                          (list_InJson_to_manifest_set
+                          (list_InJson_to_manifest_set_pairs
+                            coq_Stringifiable_ID_Type
                             coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
-                            temp_PUBKEY_PLCS) (fn pUBKEY_PLCS =>
-                          res_bind
-                            (list_InJson_to_manifest_set
-                              coq_Stringifiable_ID_Type coq_Eq_Class_ID_Type
-                              temp_TARGET_PLCS) (fn tARGET_PLCS =>
-                            res_bind
-                              (list_InJson_to_manifest_set_pairs
-                                coq_Stringifiable_ID_Type
-                                coq_Stringifiable_ID_Type
-                                coq_Eq_Class_ID_Type coq_Eq_Class_ID_Type
-                                temp_POLICY) (fn pOLICY => Coq_resultC
-                              (Build_Manifest aBS_PLC aSPS aPPR_ASPS
-                              uUID_PLCS pUBKEY_PLCS tARGET_PLCS pOLICY)))))))))))))))
+                            coq_Eq_Class_ID_Type temp_POLICY) (fn pOLICY =>
+                          Coq_resultC (Build_Manifest aBS_PLC aSPS uUID_PLCS
+                          pUBKEY_PLCS tARGET_PLCS pOLICY)))))))))))))
 
 (** val coq_Jsonifiable_Manifest : coq_Manifest coq_Jsonifiable **)
 

--- a/extracted/Manifest_JSON_Vars.cml
+++ b/extracted/Manifest_JSON_Vars.cml
@@ -38,6 +38,11 @@ val coq_MAN_POLICY : string =
 val coq_AM_CLONE_UUUID : string =
   "CLONE_UUID"
 
+(** val coq_AM_LIB_ASPS : string **)
+
+val coq_AM_LIB_ASPS : string =
+  "LIB_ASPS"
+
 (** val coq_AM_LIB_PLCS : string **)
 
 val coq_AM_LIB_PLCS : string =
@@ -47,3 +52,8 @@ val coq_AM_LIB_PLCS : string =
 
 val coq_AM_LIB_PUBKEYS : string =
   "LIB_PUBKEYS"
+
+(** val coq_AM_LIB_COMPAT_ASPS : string **)
+
+val coq_AM_LIB_COMPAT_ASPS : string =
+  "ASP_COMPAT_MAP"

--- a/extracted/Manifest_JSON_Vars.cml
+++ b/extracted/Manifest_JSON_Vars.cml
@@ -8,11 +8,6 @@ val coq_MAN_ABS_PLC : string =
 val coq_MAN_ASPS : string =
   "ASPS"
 
-(** val coq_MAN_APPR_ASPS : string **)
-
-val coq_MAN_APPR_ASPS : string =
-  "APPR_ASPS"
-
 (** val coq_MAN_UUUID_PLCS : string **)
 
 val coq_MAN_UUUID_PLCS : string =

--- a/extracted/Manifest_Union.cml
+++ b/extracted/Manifest_Union.cml
@@ -1,14 +1,11 @@
 (** val manifest_union : coq_Manifest -> coq_Manifest -> coq_Manifest **)
 
 fun manifest_union m1 m2 =
-  let val Build_Manifest myPlc asps1 app_asps1 uuidPlcs1 pubKeyPlcs1
-    targPlcs1 myPol = m1
+  let val Build_Manifest myPlc asps1 uuidPlcs1 pubKeyPlcs1 targPlcs1 myPol =
+    m1
   in
-  let val Build_Manifest _ asps2 app_asps2 uuidPlcs2 pubKeyPlcs2 targPlcs2
-    _ = m2
-  in
+  let val Build_Manifest _ asps2 uuidPlcs2 pubKeyPlcs2 targPlcs2 _ = m2 in
   Build_Manifest myPlc (manset_union coq_Eq_Class_ID_Type asps1 asps2)
-  (manset_union coq_Eq_Class_ID_Type app_asps1 app_asps2)
   (manset_union coq_Eq_Class_ID_Type uuidPlcs1 uuidPlcs2)
   (manset_union coq_Eq_Class_ID_Type pubKeyPlcs1 pubKeyPlcs2)
   (manset_union coq_Eq_Class_ID_Type targPlcs1 targPlcs2) myPol end end

--- a/extracted/Manifest_Union.cml
+++ b/extracted/Manifest_Union.cml
@@ -8,8 +8,7 @@ fun manifest_union m1 m2 =
     _ = m2
   in
   Build_Manifest myPlc (manset_union coq_Eq_Class_ID_Type asps1 asps2)
-  (manset_union (pair_EqClass coq_Eq_Class_ID_Type coq_Eq_Class_ID_Type)
-    app_asps1 app_asps2)
+  (manset_union coq_Eq_Class_ID_Type app_asps1 app_asps2)
   (manset_union coq_Eq_Class_ID_Type uuidPlcs1 uuidPlcs2)
   (manset_union coq_Eq_Class_ID_Type pubKeyPlcs1 pubKeyPlcs2)
   (manset_union coq_Eq_Class_ID_Type targPlcs1 targPlcs2) myPol end end

--- a/stubs/IO_Stubs.sml
+++ b/stubs/IO_Stubs.sml
@@ -31,10 +31,10 @@ fun make_JSON_Network_Request (u : coq_UUID) (js : coq_JSON) =
   end) : (coq_JSON, string) coq_ResultT 
 
 (** val make_JSON_FS_Location_Request :
-    coq_FS_Location -> coq_ASP_ID -> coq_JSON -> (coq_JSON, string)
+    coq_FS_Location -> coq_Concrete_ASP_ID -> coq_JSON -> (coq_JSON, string)
     coq_ResultT **)
-fun make_JSON_FS_Location_Request (aspBin : coq_FS_Location) (aspId : coq_ASP_ID) (js : coq_JSON) = 
-  (let val loc = aspBin ^ "/" ^ aspId
+fun make_JSON_FS_Location_Request (aspBin : coq_FS_Location) (conc_asp_id : coq_Concrete_ASP_ID) (js : coq_JSON) = 
+  (let val loc = aspBin ^ "/" ^ coq_Concrete_ASP_ID
       val _ = print ("Sending a request to the FS: " ^ loc ^ "\n")
       val req_str = loc ^ " \"" ^ (SysFFI.shellEscapeString (coq_JSON_to_string js)) ^ "\""
       val _ = print ("Request string: " ^ req_str ^ "\n")

--- a/stubs/IO_Stubs.sml
+++ b/stubs/IO_Stubs.sml
@@ -34,7 +34,7 @@ fun make_JSON_Network_Request (u : coq_UUID) (js : coq_JSON) =
     coq_FS_Location -> coq_Concrete_ASP_ID -> coq_JSON -> (coq_JSON, string)
     coq_ResultT **)
 fun make_JSON_FS_Location_Request (aspBin : coq_FS_Location) (conc_asp_id : coq_Concrete_ASP_ID) (js : coq_JSON) = 
-  (let val loc = aspBin ^ "/" ^ coq_Concrete_ASP_ID
+  (let val loc = aspBin ^ "/" ^ (conc_asp_id)
       val _ = print ("Sending a request to the FS: " ^ loc ^ "\n")
       val req_str = loc ^ " \"" ^ (SysFFI.shellEscapeString (coq_JSON_to_string js)) ^ "\""
       val _ = print ("Request string: " ^ req_str ^ "\n")
@@ -130,5 +130,5 @@ fun appraise_auth_tok appres = True
 fun is_local_appraisal amLib =
   (* Basically if we dont have a clone its local *)
   case amLib of 
-    Build_AM_Library clone_uuid _ _ => clone_uuid = ""
+    Build_AM_Library clone_uuid _ _ _ _ => clone_uuid = ""
 

--- a/stubs/Manifest_Admits.sml
+++ b/stubs/Manifest_Admits.sml
@@ -3,6 +3,14 @@
 
 type coq_FS_Location = string
 
+type coq_Concrete_ASP_ID = string
+
+(** val coq_Stringifiable_Concrete_ASP_ID :
+    coq_Concrete_ASP_ID coq_Stringifiable **)
+
+val coq_Stringifiable_Concrete_ASP_ID : coq_Concrete_ASP_ID coq_Stringifiable =
+  Build_Stringifiable (fn v => v) (fn v => Coq_resultC v)
+
 type coq_UUID = string (* AXIOM TO BE REALIZED *)
 
 (** val coq_Stringifiable_UUUID : coq_UUID coq_Stringifiable **)

--- a/stubs/Params_Admits.sml
+++ b/stubs/Params_Admits.sml
@@ -1,6 +1,6 @@
 (** val sig_params : coq_ASP_PARAMS **)
 
-val sig_aspid = "sigid"
+val sig_aspid = "sig_id"
 (*
 val sig_params = Coq_asp_paramsC sig_aspid [] "0" "sigtargid"
 *)
@@ -14,7 +14,7 @@ val sig_params = Coq_asp_paramsC sig_aspid sig_aspargs sig_targplc sig_targid
 
 (** val hsh_params : coq_ASP_PARAMS **)
 
-val hsh_aspid = "hshid"
+val hsh_aspid = "hsh_id"
 
 val hsh_aspargs = []
 
@@ -27,7 +27,7 @@ val hsh_params = Coq_asp_paramsC hsh_aspid hsh_aspargs hsh_targplc hsh_targid
 
 (** val enc_params :: coq_Plc -> coq_ASP_PARAMS **)
 
-val enc_aspid = "encid"
+val enc_aspid = "enc_id"
 
 val enc_aspargs = []
 

--- a/tests/CI/Test.sh
+++ b/tests/CI/Test.sh
@@ -105,9 +105,9 @@ if [[ "$REPO_ROOT" == */am-cakeml ]]; then
   
   # Now send the request, on the very last window
   sleep 1 
-  $TESTS_DIR/send_term_req.sh -h $IP -p $PORT -f $TERM_FILE > $GENERATED/output.out
+  $TESTS_DIR/send_term_req.sh -h $IP -p $PORT -f $TERM_FILE > $GENERATED/output_resp.json
   # We need this to be the last line so that the exit code is whether or not we found success
-  grep "\"SUCCESS\":true" $GENERATED/output.out
+  grep "\"SUCCESS\":true" $GENERATED/output_resp.json
 else
   echo "You are in $PWD, with the root set as $REPO_ROOT, but youre root should be 'am-cakeml'"
 fi

--- a/tests/CI/Test.sh
+++ b/tests/CI/Test.sh
@@ -92,7 +92,7 @@ if [[ "$REPO_ROOT" == */am-cakeml ]]; then
   $TESTS_DIR/term_to_term_pair_list.sh -f $TERM_FILE
 
   # First, generate the manifests
-  $MAN_GEN -t $GENERATED/TermPairList.json -e $DEMO_FILES/Evid_List.json -o $GENERATED
+  $MAN_GEN -t $GENERATED/TermPairList.json -e $DEMO_FILES/Evid_List.json -l $TEST_AM_LIB -o $GENERATED
 
   PIDS=()
   

--- a/tests/CI/Test.sh
+++ b/tests/CI/Test.sh
@@ -4,11 +4,8 @@ set -eu
 ################ PATH VARS ################
 # Assumes the following structure am-cakeml/tests/CI
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-echo "CI_DIR: $CI_DIR"
 TESTS_DIR="$(cd $CI_DIR && cd .. && pwd)"
-echo "TESTS_DIR: $TESTS_DIR"
 REPO_ROOT="$(cd "$TESTS_DIR" && cd .. && pwd)"
-echo "REPO_ROOT: $REPO_ROOT"
 ################ END PATH VARS ################
 
 # Function to display usage instructions
@@ -87,7 +84,6 @@ if [[ "$REPO_ROOT" == */am-cakeml ]]; then
   # Move to build folder
   mkdir -p $REPO_ROOT/build
   cd $REPO_ROOT/build
-  ls -al
 
   # Generate the terms file
   $TERM_GEN -t $TERM_TYPE -o $TERM_FILE

--- a/tests/ClientDemo.sh
+++ b/tests/ClientDemo.sh
@@ -3,7 +3,7 @@ set -eu
 
 # Function to display usage instructions
 usage() {
-  echo "Usage: $0 -t [cert|bg|parmut|filehash|layered_bg]"
+  echo "Usage: $0 -t [filehash] (the client am only supports filehash right now)"
   exit 1
 }
 
@@ -26,10 +26,16 @@ if [[ -z "$TERM_TYPE" ]]; then
   usage
 fi
 
+if [[ "$TERM_TYPE" != "filehash" ]]; then
+  echo "Only filehash is supported by the client AM right now..."
+  usage
+  exit 1
+fi
+
 if [[ "$TERM_TYPE" == "layered_bg" ]]; then
   echo "Layered BG is not yet supported..."
   usage
-  exit 0
+  exit 1
 fi
 
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -41,6 +47,7 @@ TERM_GEN=./bin/term_to_json
 EV_GEN=./bin/evidence_to_json
 MAN_GEN=./bin/manifest_generator
 AM_EXEC=./bin/attestation_manager
+CLIENT_AM_EXEC=./bin/client_am
 
 if [ -z ${ASP_BIN+x} ]; then
   echo "Variable 'ASP_BIN' is not set" 
@@ -105,7 +112,7 @@ if [[ "$PWD" == */am-cakeml/tests ]]; then
   done
   
   # Now send the request, on the very last window
-  tmux send-keys -t $I "sleep 1 && $TESTS_DIR/send_term_req.sh -h $IP -p $PORT -f $TERM_FILE" Enter
+  tmux send-keys -t $I "sleep 1 && $CLIENT_AM_EXEC" Enter
 
   tmux attach-session -d -t ServerProcess
 

--- a/tests/DemoFiles/Test_AM_Lib.json
+++ b/tests/DemoFiles/Test_AM_Lib.json
@@ -1,5 +1,10 @@
 {
   "CLONE_UUID": "localhost:5100",
+  "LIB_ASPS": {
+    "attest_id": "attest_id",
+    "appraise_id": "appraise_id",
+    "certificate_id": "certificate_id"
+  },
   "LIB_PLCS": {
     "P0": "localhost:5000",
     "P1": "localhost:5001",
@@ -9,5 +14,6 @@
     "P5": "localhost:5005",
     "P6": "localhost:5006"
   },
-  "LIB_PUBKEYS": {}
+  "LIB_PUBKEYS": {},
+  "ASP_COMPAT_MAP": {}
 }

--- a/tests/DemoFiles/Test_AM_Lib.json
+++ b/tests/DemoFiles/Test_AM_Lib.json
@@ -2,7 +2,9 @@
   "CLONE_UUID": "localhost:5100",
   "LIB_ASPS": {
     "attest_id": "attest_id",
+    "hashfile_id": "hashfile_id",
     "appraise_id": "appraise_id",
+    "sig_id": "attest_id",
     "certificate_id": "certificate_id"
   },
   "LIB_PLCS": {
@@ -15,5 +17,8 @@
     "P6": "localhost:5006"
   },
   "LIB_PUBKEYS": {},
-  "ASP_COMPAT_MAP": {}
+  "ASP_COMPAT_MAP": {
+    "sig_id": "certificate_id",
+    "hashfile_id": "appraise_id"
+  }
 }

--- a/tests/DemoFiles/Test_AM_Lib.json
+++ b/tests/DemoFiles/Test_AM_Lib.json
@@ -2,7 +2,7 @@
   "CLONE_UUID": "localhost:5100",
   "LIB_ASPS": {
     "attest_id": "attest_id",
-    "hashfile_id": "hashfile_id",
+    "hashfile_id": "attest_id",
     "appraise_id": "appraise_id",
     "sig_id": "attest_id",
     "certificate_id": "certificate_id"

--- a/tests/evidence_to_evidence_pair_list.sh
+++ b/tests/evidence_to_evidence_pair_list.sh
@@ -3,12 +3,12 @@
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 GENERATED=$TESTS_DIR/DemoFiles/Generated
-TOP_PLC="P0"
-TERM_PAIR_FILE=$GENERATED/TermPairList.json
+TOP_PLC="P3"
+TERM_PAIR_FILE=$GENERATED/EvidencePairList.json
 
 # Function to display usage instructions
 usage() {
-  echo "Usage: $0 -f <json_term_file>"
+  echo "Usage: $0 -f <json_evidence_file>"
   exit 1
 }
 
@@ -38,8 +38,8 @@ fi
 # Read JSON data from the file
 JSON_TERM_DATA=$(cat "$JSON_TERM_FILE")
 
-# Build Term_Plc_list JSON structure
-TERM_FILE_JSON="{ \"Term_Plc_list\": [ [$JSON_TERM_DATA, \"$TOP_PLC\" ] ] }" 
+# Build Evidnce_Plc_list JSON structure
+TERM_FILE_JSON="{ \"Evidence_Plc_list\": [ [$JSON_TERM_DATA, \"$TOP_PLC\" ] ] }" 
 
 # Write to generated temporarily
 echo $TERM_FILE_JSON > $TERM_PAIR_FILE

--- a/util/AM_CLI.sml
+++ b/util/AM_CLI.sml
@@ -70,14 +70,17 @@ structure AM_CLI_Utils = struct
   
   fun retrieve_Client_AM_CLI_args _ =
     let val name = CommandLine.name ()
-        val usage = ("Usage: " ^ name ^ "-m <ManifestFile>.json -t <term_file>.json\n\ne.g.\t" ^ name ^ " -m formMan.json -t cert.json\n\n")
+        val usage = ("Usage: " ^ name ^ "you basically cant use this wrong")
+        val argList = CommandLine.arguments ()
+        (* val usage = ("Usage: " ^ name ^ "-m <ManifestFile>.json -t <term_file>.json\n\ne.g.\t" ^ name ^ " -m formMan.json -t cert.json\n\n")
         val argList = CommandLine.arguments ()
         val manInd        = ListExtra.find_index argList "-m"
         val termInd        = ListExtra.find_index argList "-t"
         val manIndBool    = argIndPresent manInd 
-        val termIndBool   = argIndPresent termInd 
+        val termIndBool   = argIndPresent termInd  *)
     in 
-    if ((manIndBool = False) orelse (termIndBool = False))
+      ()
+    (* if ((manIndBool = False) orelse (termIndBool = False))
     then raise (Exception ("Invalid Arguments\n" ^ usage))
     else (
       let val manFileName   = List.nth argList (manInd + 1)
@@ -86,19 +89,19 @@ structure AM_CLI_Utils = struct
         (case (parse_manifest_from_file manFileName) of
           Coq_errC e => raise (Exception ("Could not parse JSON Manifest file: " ^ e ^ "\n"))
         | Coq_resultC manifest =>
-          (case (parse_term_from_file term_file) of
+          (case (parse_term_from_file termFileName) of
             Coq_errC e => raise (Exception ("Could not parse Term file: " ^ e ^ "\n"))
           | Coq_resultC term => (manifest, term)
           )
           )
-      end)
+      end) *)
     end
 
   (* Retrieves the manifest filename and private key (as strings)
     based upon Command Line arguments
     : () -> am_args_t
   *)
-  fun retrieve_AM_Server_CLI_args _ =
+  fun retrieve_Server_AM_CLI_args _ =
     let val name = CommandLine.name ()
         val usage = ("Usage: " ^ name ^ "-m <ManifestFile>.json -l <AmLibFile>.json -b <asp_bin_location> (-k <privateKeyFile>)\n\ne.g.\t" ^ name ^ " -m formMan.json -l amLib.json -b /opt/asps -k ~/.ssh/id_ed25519\n\n")
         val argList = CommandLine.arguments ()
@@ -131,7 +134,7 @@ structure AM_CLI_Utils = struct
               | Coq_resultC am_lib =>
                 (case (parse_private_key privKeyFile) of
                   Coq_errC e => raise (Exception ("Could not parse private key file: " ^ e ^ "\n"))
-                | Coq_resultC priv_key => Some (manifest, am_lib, aspBinLoc, priv_key)
+                | Coq_resultC priv_key => (manifest, am_lib, aspBinLoc, priv_key)
                 )
               )
             )


### PR DESCRIPTION
- Reworks the AM Library so that ASPs are mentioned in it, and a compatibility mapping of ASP to Appraisal ASP is included.
- Creates a Client AM target that runs a simple demo phrase (just as an example, not a reusable workflow)